### PR TITLE
inputValidation.errorForeground color contrast fixed

### DIFF
--- a/themes/City Lights-color-theme.json
+++ b/themes/City Lights-color-theme.json
@@ -126,6 +126,7 @@
     "input.foreground": "#b7c5d3",
     "input.placeholderForeground": "#aaa",
     "inputOption.activeBorder": "#333F4A",
+    "inputValidation.errorForeground": "#fff",
     "inputValidation.errorBackground": "#e27e8d",
     "inputValidation.errorBorder": "#d95468",
     "inputValidation.infoBackground": "#5ec4ff",


### PR DESCRIPTION
Hi,
I noticed a small contrast issue earlier today.
<img width="543" alt="screenshot 2019-02-06 at 13 50 06" src="https://user-images.githubusercontent.com/3235874/52368126-ff903500-2a4d-11e9-901d-59cc2ee7364a.png">

This is just a quick fix that changes the contrast so it's readable.
Hope you'll approve it,
Cheers!