### PR TITLE
Add Diff syntax highlighting

### DIFF
--- a/themes/City Lights-color-theme.json
+++ b/themes/City Lights-color-theme.json
@@ -789,7 +789,7 @@
         "entity.other.inherited-class.java",
       ],
       "settings": {
-        
+
         "foreground": "#d98e48"
       }
     },
@@ -869,6 +869,27 @@
       ],
       "settings": {
         "foreground": "#8bd49c"
+      }
+    },
+    {
+      "name": "Inserted line markup",
+      "scope": "markup.inserted",
+      "settings": {
+        "foreground": "#8bd49c"
+      }
+    },
+    {
+      "name": "Deleted line markup",
+      "scope": "markup.deleted",
+      "settings": {
+        "foreground": "#e27e8d"
+      }
+    },
+    {
+      "name": "Changed line markup",
+      "scope": "markup.changed",
+      "settings": {
+        "foreground": "#ebbf83"
       }
     },
   ]


### PR DESCRIPTION
Add an ability to highlight diff/patch files. Reusing the colors from gitDecorator.

For preview, this is what we see when viewing diff file before the change:

![image](https://user-images.githubusercontent.com/613943/80153503-84dc0880-8572-11ea-9eb5-5500b7ff47e8.png)

And this is the result after the change:

![image](https://user-images.githubusercontent.com/613943/80153533-92918e00-8572-11ea-82f0-4c57cac2f418.png)

Fixes #63 